### PR TITLE
fix: Dockerfile jdk 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 amazoncorretto:17
+FROM openjdk:17
 
 ENV TZ=Asia/Seoul
 


### PR DESCRIPTION
## 🏷 연관 이슈

- close #16 

## 🥅 구현 목적
corretto jdk가 pull 되지 않아 수정하였습니다.

## 📌 구현 내용

## 🧐 고려사항

## 🚀 향후 진행 방향
해결되지 않으면 원인 재점검 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Docker 환경이 업데이트되어 Java 런타임이 OpenJDK 17으로 전환되었으며, 특정 플랫폼 제약이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->