### PR TITLE
[FEAT] 페이퍼 복수 조회 페이지네이션 prevCursor 응답값 추가 (issue #19)

### DIFF
--- a/src/main/java/com/zollingpaper/backend/paper/dto/PaperDetailPaginationResponse.java
+++ b/src/main/java/com/zollingpaper/backend/paper/dto/PaperDetailPaginationResponse.java
@@ -2,5 +2,5 @@ package com.zollingpaper.backend.paper.dto;
 
 import java.util.List;
 
-public record PaperDetailPaginationResponse(List<PaperDetailResponse> responses, Boolean hasNext, Long nextCursor) {
+public record PaperDetailPaginationResponse(List<PaperDetailResponse> responses, Boolean hasNext, Long prevCursor, Long nextCursor) {
 }

--- a/src/main/java/com/zollingpaper/backend/paper/service/PaperService.java
+++ b/src/main/java/com/zollingpaper/backend/paper/service/PaperService.java
@@ -66,7 +66,7 @@ public class PaperService {
                 .map(PaperDetailResponse::from)
                 .toList();
 
-        return new PaperDetailPaginationResponse(responses, hasNext, getNextCursor(hasNext, papers));
+        return new PaperDetailPaginationResponse(responses, hasNext, cursor, getNextCursor(hasNext, papers));
     }
 
     private List<Paper> findPaginatedPapers(Long boardId, Long cursor, Pageable pageable) {


### PR DESCRIPTION
## 🏷 연관 이슈

- close #19 

## 🥅 구현 목적

클라이언트 요청

## 📌 구현 내용

null로 요청하는 경우에도 0으로 보내줄까 고민 했었는데 다음 페이지가 없는 경우 nextCursor도 null을 보내주는 로직으로 구현했습니다.
클라이언트에서 요청준 cursor를 그대로 리턴하는 로직이 문제가 없을 것으로 판단했습니다.

### `/board/1/papers/paging?limit=2` 클라이언트가 cursor를 파라미터에 포함하지 않고 요청한 경우 

```json
{
  "responses": [
    {
      "id": 1,
      "boardId": 1,
      "createdAt": "2024-12-30T10:00:00",
      "name": "작성자2",
      "content": "내용2"
    },
    {
      "id": 2,
      "boardId": 1,
      "createdAt": "2024-12-30T10:10:00",
      "name": "작성자3",
      "content": "내용3"
    }
  ],
  "hasNext": true,
  "prevCursor": null,
  "nextCursor": 3
}
```

### `/board/1/papers/paging?cursor=0&limit=2` 클라이언트가 cursor를 파라미터에 포함해 요청한 경우

```json
{
  "responses": [
    {
      "id": 1,
      "boardId": 1,
      "createdAt": "2024-12-30T10:00:00",
      "name": "작성자2",
      "content": "내용2"
    },
    {
      "id": 2,
      "boardId": 1,
      "createdAt": "2024-12-30T10:10:00",
      "name": "작성자3",
      "content": "내용3"
    }
  ],
  "hasNext": true,
  "prevCursor": 0,
  "nextCursor": 3
}
```

## 🧐 고려사항

## 🚀 향후 진행 방향


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 페이지 네이션 응답에 추가 정보가 포함되어 결과 목록의 양방향 탐색 기능이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->