### PR TITLE
[FEAT] Board 비밀번호 형식 검증 로직 추가

### DIFF
--- a/src/main/java/com/zollingpaper/backend/board/domain/Board.java
+++ b/src/main/java/com/zollingpaper/backend/board/domain/Board.java
@@ -1,5 +1,6 @@
 package com.zollingpaper.backend.board.domain;
 
+import jakarta.persistence.Embedded;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import com.zollingpaper.backend.global.domain.BaseTimeEntity;
@@ -26,8 +27,8 @@ public class Board extends BaseTimeEntity {
     private String name;
 
     @NotNull
-    @Column(nullable = false, length = 4)
-    private String password;
+    @Embedded
+    private Password password;
 
     @NotNull
     @Column(nullable = false)
@@ -40,7 +41,7 @@ public class Board extends BaseTimeEntity {
         this.id = id;
         this.accessAddress = accessAddress;
         this.name = name;
-        this.password = password;
+        this.password = new Password(password);
         this.showDate = showDate;
     }
 
@@ -76,7 +77,7 @@ public class Board extends BaseTimeEntity {
     }
 
     public String getPassword() {
-        return password;
+        return password.getValue();
     }
 
     public LocalDateTime getShowDate() {

--- a/src/main/java/com/zollingpaper/backend/board/domain/Password.java
+++ b/src/main/java/com/zollingpaper/backend/board/domain/Password.java
@@ -1,0 +1,37 @@
+package com.zollingpaper.backend.board.domain;
+
+import com.zollingpaper.backend.board.exception.BoardErrorCode;
+import com.zollingpaper.backend.board.exception.BoardException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Password {
+
+    private static final String VALID_FORMAT = "^\\d{4}$";
+
+    @Column(name = "password", nullable = false, length = 4)
+    private String value;
+
+    protected Password() {
+    }
+
+    public Password(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(String value) {
+        if (value == null || isInvalidFormat(value)) {
+            throw new BoardException(BoardErrorCode.INVALID_PASSWORD_FORMAT);
+        }
+    }
+
+    private boolean isInvalidFormat(String value) {
+        return !value.matches(VALID_FORMAT);
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/zollingpaper/backend/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/zollingpaper/backend/board/exception/BoardErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 
 public enum BoardErrorCode implements ErrorResponse {
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 보드가 존재하지 않습니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 비밀번호입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/zollingpaper/backend/board/domain/PasswordTest.java
+++ b/src/test/java/com/zollingpaper/backend/board/domain/PasswordTest.java
@@ -1,0 +1,19 @@
+package com.zollingpaper.backend.board.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.zollingpaper.backend.board.exception.BoardException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class PasswordTest {
+
+    @DisplayName("password가 4자리가 아니거나, 숫자가 아닌 문자가 존재하면 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"123", "12345", "123a", "a234", "abcd"})
+    void validate_shouldThrowExceptionWhenPasswordIsInvalid(String value) {
+        assertThatThrownBy(() -> new Password(value))
+                .isInstanceOf(BoardException.class);
+    }
+}


### PR DESCRIPTION
## 🏷 연관 이슈

- close #31 

## 🥅 구현 목적
비밀번호의 형태 제한 및 검증

## 📌 구현 내용
- Password VO 분리
- Password 생성 로직 검증 추가(4자리, 숫자)
- 테스트 코드 작성

## 🧐 고려사항

## 🚀 향후 진행 방향
Password 암호화 여부 고려 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 보드의 비밀번호 입력 방식이 강화되어, 4자리 숫자 형식의 비밀번호만 허용됩니다. 잘못된 형식의 비밀번호 입력 시 사용자에게 명확한 오류 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->