### PR TITLE
[FEAT] paper 조회 시 board id uuid를 사용 (issue #30)

### DIFF
--- a/src/main/java/com/zollingpaper/backend/board/service/BoardService.java
+++ b/src/main/java/com/zollingpaper/backend/board/service/BoardService.java
@@ -35,10 +35,12 @@ public class BoardService {
     }
 
     public Board getBoardByAccessAddress(String accessAddress) {
-        return boardRepository.findByAccessAddress(accessAddress).orElseThrow(() -> new BoardException(BoardErrorCode.NOT_FOUND));
+        return boardRepository.findByAccessAddress(accessAddress)
+                .orElseThrow(() -> new BoardException(BoardErrorCode.NOT_FOUND));
     }
 
     public Board getBoard(Long boardId) {
-        return boardRepository.findById(boardId).orElseThrow(() -> new BoardException(BoardErrorCode.NOT_FOUND));
+        return boardRepository.findById(boardId)
+                .orElseThrow(() -> new BoardException(BoardErrorCode.NOT_FOUND));
     }
 }

--- a/src/main/java/com/zollingpaper/backend/board/service/BoardService.java
+++ b/src/main/java/com/zollingpaper/backend/board/service/BoardService.java
@@ -29,14 +29,16 @@ public class BoardService {
     }
 
     public BoardDetailResponse getBoardDetail(String accessAddress) {
-        Board board = boardRepository.findByAccessAddress(accessAddress)
-                .orElseThrow(() -> new BoardException(BoardErrorCode.NOT_FOUND));
+        Board board = getBoardByAccessAddress(accessAddress);
 
         return BoardDetailResponse.from(board, board.isPublic(), board.calculateRemainingDays());
     }
 
+    public Board getBoardByAccessAddress(String accessAddress) {
+        return boardRepository.findByAccessAddress(accessAddress).orElseThrow(() -> new BoardException(BoardErrorCode.NOT_FOUND));
+    }
+
     public Board getBoard(Long boardId) {
-        return boardRepository.findById(boardId)
-                .orElseThrow(() -> new BoardException(BoardErrorCode.NOT_FOUND));
+        return boardRepository.findById(boardId).orElseThrow(() -> new BoardException(BoardErrorCode.NOT_FOUND));
     }
 }

--- a/src/main/java/com/zollingpaper/backend/paper/controller/PaperController.java
+++ b/src/main/java/com/zollingpaper/backend/paper/controller/PaperController.java
@@ -49,7 +49,7 @@ public class PaperController {
     @Operation(summary = "paper 목록 조회 API", description = "특정 board의 paper 목록을 조회합니다.")
     @GetMapping("/board/{board-id}/papers")
     public ResponseEntity<PaperDetailResponses> getPaperDetails(
-            @PathVariable(value = "board-id") Long boardId
+            @PathVariable(value = "board-id") String boardId
     ) {
         PaperDetailResponses responses = paperService.getPaperDetails(boardId);
         return ResponseEntity.ok(responses);

--- a/src/main/java/com/zollingpaper/backend/paper/controller/PaperController.java
+++ b/src/main/java/com/zollingpaper/backend/paper/controller/PaperController.java
@@ -58,7 +58,7 @@ public class PaperController {
     @Operation(summary = "paper 목록 조회 페이지네이션 API", description = "특정 board의 paper 목록을 페이지네이션하여 조회합니다.")
     @GetMapping("/board/{board-id}/papers/paging")
     public ResponseEntity<PaperDetailPaginationResponse> getPaginatedPaperDetails(
-            @PathVariable(value = "board-id") Long boardId,
+            @PathVariable(value = "board-id") String boardId,
             @RequestParam(value = "cursor", required = false) Long cursor,
             @RequestParam(value = "limit", defaultValue = "10") int limit
     ) {

--- a/src/main/java/com/zollingpaper/backend/paper/dto/PaperSaveRequest.java
+++ b/src/main/java/com/zollingpaper/backend/paper/dto/PaperSaveRequest.java
@@ -1,4 +1,4 @@
 package com.zollingpaper.backend.paper.dto;
 
-public record PaperSaveRequest(Long boardId, String name, String content) {
+public record PaperSaveRequest(String boardId, String name, String content) {
 }

--- a/src/main/java/com/zollingpaper/backend/paper/repository/PaperRepository.java
+++ b/src/main/java/com/zollingpaper/backend/paper/repository/PaperRepository.java
@@ -7,9 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaperRepository extends JpaRepository<Paper, Long> {
 
-    List<Paper> findAllByBoardId(Long boardId);
-
     List<Paper> findByBoardIdOrderByIdAsc(Long boardId, Pageable pageable);
 
     List<Paper> findByBoardIdAndIdGreaterThanOrderByIdAsc(Long boardId, Long cursor, Pageable pageable);
+
+    List<Paper> findAllByBoardAccessAddress(String boardId);
 }

--- a/src/main/java/com/zollingpaper/backend/paper/service/PaperService.java
+++ b/src/main/java/com/zollingpaper/backend/paper/service/PaperService.java
@@ -28,7 +28,7 @@ public class PaperService {
     }
 
     public PaperSaveResponse savePaper(PaperSaveRequest request) {
-        Board board = boardService.getBoard(request.boardId());
+        Board board = boardService.getBoardByAccessAddress(request.boardId());
         Paper paper = new Paper(board, request.name(), request.content());
         Paper savedPaper = paperRepository.save(paper);
 

--- a/src/main/java/com/zollingpaper/backend/paper/service/PaperService.java
+++ b/src/main/java/com/zollingpaper/backend/paper/service/PaperService.java
@@ -1,7 +1,6 @@
 package com.zollingpaper.backend.paper.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import com.zollingpaper.backend.board.domain.Board;
 import com.zollingpaper.backend.board.service.BoardService;
 import com.zollingpaper.backend.paper.domain.Paper;
@@ -43,11 +42,11 @@ public class PaperService {
         return PaperDetailResponse.from(paper);
     }
 
-    public PaperDetailResponses getPaperDetails(Long boardId) {
-        List<Paper> papers = paperRepository.findAllByBoardId(boardId);
+    public PaperDetailResponses getPaperDetails(String boardId) {
+        List<Paper> papers = paperRepository.findAllByBoardAccessAddress(boardId);
         List<PaperDetailResponse> responses = papers.stream()
                 .map(PaperDetailResponse::from)
-                .collect(Collectors.toList()); // TODO: toList()로 변경 필요
+                .toList();
 
         return new PaperDetailResponses(responses);
     }

--- a/src/main/java/com/zollingpaper/backend/paper/service/PaperService.java
+++ b/src/main/java/com/zollingpaper/backend/paper/service/PaperService.java
@@ -51,8 +51,8 @@ public class PaperService {
         return new PaperDetailResponses(responses);
     }
 
-    public PaperDetailPaginationResponse getPaperDetailPagination(Long boardId, Long cursor, int limit) {
-        Board board = boardService.getBoard(boardId);
+    public PaperDetailPaginationResponse getPaperDetailPagination(String boardId, Long cursor, int limit) {
+        Board board = boardService.getBoardByAccessAddress(boardId);
         Pageable pageable = PageRequest.of(0, limit + 1);
         List<Paper> papers = findPaginatedPapers(board.getId(), cursor, pageable);
 

--- a/src/test/java/com/zollingpaper/backend/paper/controller/PaperControllerE2ETest.java
+++ b/src/test/java/com/zollingpaper/backend/paper/controller/PaperControllerE2ETest.java
@@ -103,7 +103,7 @@ public class PaperControllerE2ETest {
 
                 dynamicTest("1번 보드에 해당하는 편지를 모두 조회한다.", () -> {
                     RestAssured.given().log().all()
-                            .when().get("/board/1/papers")
+                            .when().get("/board/" + accessAddress + "/papers")
                             .then().log().all()
                             .statusCode(200).body("responses.size()", is(2));
                 })

--- a/src/test/java/com/zollingpaper/backend/paper/domain/PaperFixture.java
+++ b/src/test/java/com/zollingpaper/backend/paper/domain/PaperFixture.java
@@ -7,21 +7,21 @@ public class PaperFixture {
 
     public static final PaperSaveRequest PAPER_SAVE_REQUEST_1
             = new PaperSaveRequest(
-            1L,
+            "test-address",
             "Mason_",
             "hello"
     );
 
     public static final PaperSaveRequest PAPER_SAVE_REQUEST_2
             = new PaperSaveRequest(
-            1L,
+            "test-address",
             "Liv_",
             "hello World"
     );
 
     public static final PaperSaveRequest PAPER_SAVE_REQUEST_3
             = new PaperSaveRequest(
-            2L,
+            "test-address",
             "Todari_",
             "hello World!"
     );


### PR DESCRIPTION
## 🏷 연관 이슈

- close #30

## 🥅 구현 목적

## 📌 구현 내용

### 페이퍼 생성
#### Request
```json
{
    "boardId": "abc",
    "name": "민주",
    "content": "새로운 페이퍼"
}
```

### 페이퍼 목록 조회
#### Request
```
/board/abc/papers/paging?cursor=0&limit=2
```

## 🧐 고려사항

## 🚀 향후 진행 방향


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 보드 조회 시 기존의 숫자 식별자 대신 문자열 형태의 접근 주소를 사용할 수 있도록 개선되었습니다.
- **리팩토링**
	- 보드 및 문서 세부 정보 조회 API의 보드 식별자 타입이 변경되어 일관성과 재사용성이 향상되었습니다.
- **테스트**
	- 관련 테스트 케이스와 데이터 샘플이 새로운 보드 접근 방식에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->